### PR TITLE
feat: add dracut module

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,6 @@ You can check whether or not your token is suitable by executing `fido2-token -I
 
 Copy `clevis-encrypt-fido2` and `clevis-encrypt-fido2` to the `$PATH` directory in which clevis is installed (or any local bin path if it should only work for the current user).
 
+## Dracut
 
+Copy the contents of `dracut/` to one of the dracut configuration directories: `/usr/lib/dracut/` or `/etc/dracut/`. This module depends on the Clevis module. Due to dracut limitations, `clevis-{decrypt,encrypt}-fido2` scripts must reside in directories that dracut scans for executables (ignores `$PATH`): `/bin:/sbin:/usr/bin:/usr/sbin`.

--- a/dracut/modules.d/60clevis-pin-fido2/module-setup.sh
+++ b/dracut/modules.d/60clevis-pin-fido2/module-setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright (c) 2024 Benjamino Masyura <benjama@keemail.me>
+
+check() {
+    require_binaries clevis-decrypt-fido2 fido2-token fido2-assert jose head tail cut wc printf base64 dd || return 1
+    return 0
+}
+
+depends() {
+    echo clevis udev-rules
+    return 0
+}
+
+install() {
+    inst_multiple clevis-decrypt-fido2 fido2-token fido2-assert jose head tail cut wc printf base64 dd
+    inst_libdir_file \
+        {"tls/$_arch/",tls/,"$_arch/",}"libfido2.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libz.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libcbor.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libhidapi-hidraw.so.*"
+}
+
+installkernel() {
+    hostonly='' instmods =drivers/hid/usbhid
+}
+
+


### PR DESCRIPTION
I'm using Clevis with FIDO2 on Gentoo, and I wrote a small module for dracut to unlock the drives at initramfs stage. 